### PR TITLE
use UserKey table in xbr schema as well

### DIFF
--- a/cfxdb/xbr/__init__.py
+++ b/cfxdb/xbr/__init__.py
@@ -17,6 +17,8 @@ from cfxdb.xbr.market import Market, Markets, IndexMarketsByOwner, IndexMarketsB
 from cfxdb.xbr.member import Member, Members
 from cfxdb.xbr.token import TokenApproval, TokenApprovals, TokenTransfer, TokenTransfers
 
+from cfxdb.xbrnetwork.userkey import UserKey
+
 from cfxdb.gen.xbr.ActorType import ActorType
 from cfxdb.gen.xbr.MemberLevel import MemberLevel
 
@@ -49,4 +51,5 @@ __all__ = (
     'TokenApproval',
     'TokenApprovals',
     'TokenTransfer',
-    'TokenTransfers')
+    'TokenTransfers',
+    'UserKey')

--- a/cfxdb/xbr/schema.py
+++ b/cfxdb/xbr/schema.py
@@ -22,6 +22,8 @@ from cfxdb.xbrmm.offer import Offers, IndexOfferByKey
 from .token import TokenApprovals, TokenTransfers
 from cfxdb.xbrmm.transaction import Transactions
 
+from cfxdb.xbrnetwork.userkey import UserKeys, IndexUserKeyByAccount
+
 
 class Schema(object):
     """
@@ -159,6 +161,16 @@ class Schema(object):
     """
     """
 
+    user_keys: UserKeys
+    """
+    User client keys database table :class:`xbrnetwork.UserKeys`.
+    """
+
+    idx_user_key_by_account: IndexUserKeyByAccount
+    """
+    Index "by pubkey" of user keys :class:`xbrnetwork.IndexUserKeyByAccount`.
+    """
+
     @staticmethod
     def attach(db):
         """
@@ -235,6 +247,12 @@ class Schema(object):
         schema.offers = db.attach_table(Offers)
         schema.idx_offer_by_key = db.attach_table(IndexOfferByKey)
         schema.offers.attach_index('idx1', schema.idx_offer_by_key, lambda offer: offer.key)
+
+        schema.user_keys = db.attach_table(UserKeys)
+
+        schema.idx_user_key_by_account = db.attach_table(IndexUserKeyByAccount)
+        schema.user_keys.attach_index('idx1', schema.idx_user_key_by_account, lambda user_key:
+                                      (user_key.owner, user_key.created))
 
         schema.transactions = db.attach_table(Transactions)
 


### PR DESCRIPTION
This currently imports UserKey table definition from the `xbrnetwork` namepsace and adds it to the `xbr` namespace. I avoid rewriting the exact same table. If that is wrong, do let me know and I'll create a separate table.