### PR TITLE
add index by maker for markets

### DIFF
--- a/cfxdb/xbr/__init__.py
+++ b/cfxdb/xbr/__init__.py
@@ -13,7 +13,7 @@ from cfxdb.xbr.block import Block, Blocks
 from cfxdb.xbr.catalog import Catalog, Catalogs
 from cfxdb.xbr.consent import Consent, Consents, IndexConsentByMemberAddress
 
-from cfxdb.xbr.market import Market, Markets, IndexMarketsByOwner, IndexMarketsByActor
+from cfxdb.xbr.market import Market, Markets, IndexMarketsByOwner, IndexMarketsByActor, IndexMarketsByMaker
 from cfxdb.xbr.member import Member, Members
 from cfxdb.xbr.token import TokenApproval, TokenApprovals, TokenTransfer, TokenTransfers
 
@@ -44,6 +44,7 @@ __all__ = (
     'Markets',
     'IndexMarketsByOwner',
     'IndexMarketsByActor',
+    'IndexMarketsByMaker',
     'Member',
     'Members',
     'TokenApproval',

--- a/cfxdb/xbr/market.py
+++ b/cfxdb/xbr/market.py
@@ -11,7 +11,7 @@ import flatbuffers
 import numpy as np
 from cfxdb import pack_uint256, unpack_uint256
 from cfxdb.gen.xbr import Market as MarketGen
-from zlmdb import table, MapUuidFlatBuffers, MapBytes20TimestampUuid
+from zlmdb import table, MapUuidFlatBuffers, MapBytes20TimestampUuid, MapBytes20Uuid
 
 
 class _MarketGen(MarketGen.Market):
@@ -523,4 +523,11 @@ class IndexMarketsByOwner(MapBytes20TimestampUuid):
 class IndexMarketsByActor(MapBytes20TimestampUuid):
     """
     Markets-by-actor index with ``(actor_adr|bytes[20], joined|int) -> market_id|UUID`` mapping.
+    """
+
+
+@table('d511774c-0c7b-4d3f-a2de-6748c072a56f')
+class IndexMarketsByMaker(MapBytes20Uuid):
+    """
+    Markets-by-maker index with ``maker_adr|bytes[20] -> market_id|UUID`` mapping.
     """

--- a/cfxdb/xbr/schema.py
+++ b/cfxdb/xbr/schema.py
@@ -213,8 +213,7 @@ class Schema(object):
         #                            (actor.actor, actor.timestamp))
 
         schema.idx_markets_by_maker = db.attach_table(IndexMarketsByMaker)
-        schema.markets.attach_index('idx3', schema.idx_markets_by_maker, lambda market:
-                                    market.maker)
+        schema.markets.attach_index('idx3', schema.idx_markets_by_maker, lambda market: market.maker)
 
         schema.payment_channels = db.attach_table(PaymentChannels)
 

--- a/cfxdb/xbr/schema.py
+++ b/cfxdb/xbr/schema.py
@@ -16,7 +16,7 @@ from cfxdb.xbrmm.channel import PaymentChannels, IndexPaymentChannelByDelegate, 
     IndexPaymentChannelByActor, PaymentChannelBalances, PayingChannels, IndexPayingChannelByDelegate, \
     IndexPayingChannelByRecipient, PayingChannelBalances
 
-from .market import Markets, IndexMarketsByOwner, IndexMarketsByActor
+from .market import Markets, IndexMarketsByOwner, IndexMarketsByActor, IndexMarketsByMaker
 from .member import Members
 from cfxdb.xbrmm.offer import Offers, IndexOfferByKey
 from .token import TokenApprovals, TokenTransfers
@@ -83,6 +83,11 @@ class Schema(object):
     idx_markets_by_actor: IndexMarketsByActor
     """
     Index ``(actor_adr, joined) -> market_oid``.
+    """
+
+    idx_markets_by_maker: IndexMarketsByMaker
+    """
+    Index ``maker_adr -> market_oid``.
     """
 
     actors: Actors
@@ -206,6 +211,10 @@ class Schema(object):
 
         # schema.actors.attach_index('idx1', schema.idx_markets_by_actor, lambda actor:
         #                            (actor.actor, actor.timestamp))
+
+        schema.idx_markets_by_maker = db.attach_table(IndexMarketsByMaker)
+        schema.markets.attach_index('idx3', schema.idx_markets_by_maker, lambda market:
+                                    market.maker)
 
         schema.payment_channels = db.attach_table(PaymentChannels)
 


### PR DESCRIPTION
This is needed for a check during a new market creation on xbr network. Using this we can check upfront if the provided market maker is already running a market.

Without this change, we were hitting https://github.com/crossbario/xbr-protocol/blob/825d54c9e222582dfae60504f6827ed561dd1d49/contracts/XBRNetwork.sol#L150, with the proposed change, we can check that upfront, before sending the request to the blockchain.